### PR TITLE
Clarify and expand dependencies list

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,9 @@ There are two ways of running MINING-D.
 **Dependencies**
 
 - Biopython 
-- Networkx
+- Networkx<2.4
 - Joblib
 - NumPy
 - SciPy
+- [click](https://palletsprojects.com/p/click/)
 


### PR DESCRIPTION
This PR just modifies a few lines in the Readme to clarify dependencies:  I found that the latest versions of NetworkX no longer have the `connected_component_subgraphs` function, so I needed to install version 2.4 to make it work with MINING-D.  I also needed [click](https://palletsprojects.com/p/click/) to make the command-line interface work.

Thanks for providing this tool!